### PR TITLE
change logger to be initailised before event manager is used in health check

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/Application.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/Application.java
@@ -41,24 +41,4 @@ public class Application {
     return mapper;
   }
 
-  @Value("#{'${logging.profile}' == 'CLOUD'}")
-  private boolean useJsonLogging;
-
-  @PostConstruct
-  public void initJsonLogging() {
-    HashMap<Class<?>, Function<Object, String>> customMappers = new HashMap<>();
-    customMappers.put(LocalTime.class, Object::toString);
-    customMappers.put(LocalDateTime.class, Object::toString);
-
-    LoggingConfigs configs;
-
-    if (useJsonLogging) {
-      configs = LoggingConfigs.builder().customMapper(customMappers).build().useJson();
-    }
-    else {
-      configs = LoggingConfigs.builder().customMapper(customMappers).build();
-    }
-    LoggingConfigs.setCurrent(configs);
-  }
-
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/config/GatewayEventsConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/config/GatewayEventsConfig.java
@@ -1,9 +1,17 @@
 package uk.gov.ons.census.fwmt.outcomeservice.config;
 
+import com.godaddy.logging.LoggingConfigs;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
 import uk.gov.ons.census.fwmt.outcomeservice.Application;
+
+import javax.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.function.Function;
 
 @Configuration
 public class GatewayEventsConfig {
@@ -41,5 +49,29 @@ public class GatewayEventsConfig {
         CCS_FAILED_FULFILMENT_REQUEST_INVALID, RABBIT_QUEUE_DOWN, REDIS_SERVICE_DOWN});
     
     return gatewayEventManager;
+  }
+
+  @Value("#{'${logging.profile}' == 'CLOUD'}")
+  private boolean useJsonLogging;
+
+  /**
+   * This method needs to be called before the Gateway event Manager is used,
+   * if not the logger will not be properly initialised
+   */
+  @PostConstruct
+  public void initJsonLogging() {
+    HashMap<Class<?>, Function<Object, String>> customMappers = new HashMap<>();
+    customMappers.put(LocalTime.class, Object::toString);
+    customMappers.put(LocalDateTime.class, Object::toString);
+
+    LoggingConfigs configs;
+
+    if (useJsonLogging) {
+      configs = LoggingConfigs.builder().customMapper(customMappers).build().useJson();
+    }
+    else {
+      configs = LoggingConfigs.builder().customMapper(customMappers).build();
+    }
+    LoggingConfigs.setCurrent(configs);
   }
 }


### PR DESCRIPTION
when the logger was being initialised in the main application the configuration was being ignored as the gateway event manager had already been initialised.