### PR TITLE
Have added error when a hard refusal is received and no cache is pres…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/controller/OutcomeController.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/controller/OutcomeController.java
@@ -222,17 +222,17 @@ public class OutcomeController implements OutcomeApi {
 
     @Override
     public ResponseEntity<Void> ncOutcome(String caseID, NCOutcome ncOutcome) throws GatewayException {
+        String hhCaseId = nctmCaseIdOverride.overrideTMCaseIdWithRMOriginalCaseId(caseID);
+        ncOutcome.setCaseId(UUID.fromString(hhCaseId));
         gatewayEventManager.triggerEvent(caseID, COMET_NC_OUTCOME_RECEIVED,
-                "transactionId", ncOutcome.getTransactionId().toString(),
-                "Survey type", "NC",
-                "Primary Outcome", ncOutcome.getPrimaryOutcomeDescription(),
-                "Secondary Outcome", ncOutcome.getSecondaryOutcomeDescription(),
-                "Outcome code", ncOutcome.getOutcomeCode(),
-                "NCOutcome", ncOutcome.toString());
-
-        nctmCaseIdOverride.overrideTMCaseIdWithRMOriginalCaseId(caseID, ncOutcome);
+            "transactionId", ncOutcome.getTransactionId().toString(),
+            "Original HH CaseId", hhCaseId,
+            "Survey type", "NC",
+            "Primary Outcome", ncOutcome.getPrimaryOutcomeDescription(),
+            "Secondary Outcome", ncOutcome.getSecondaryOutcomeDescription(),
+            "Outcome code", ncOutcome.getOutcomeCode(),
+            "NCOutcome", ncOutcome.toString());
         outcomePreprocessingProducer.sendHHStandaloneAddressToPreprocessingQueue(ncOutcome);
-
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/service/impl/NCTMCaseIdOverride.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/service/impl/NCTMCaseIdOverride.java
@@ -1,22 +1,19 @@
 package uk.gov.ons.census.fwmt.outcomeservice.service.impl;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import uk.gov.ons.census.fwmt.common.data.nc.NCOutcome;
+import org.springframework.stereotype.Component;
 import uk.gov.ons.census.fwmt.outcomeservice.data.GatewayCache;
 
 import javax.transaction.Transactional;
-import java.util.UUID;
 
-@Service
+@Component
 public class NCTMCaseIdOverride {
 
     @Autowired
-    private GatewayCacheService gatewayCacheService;
+    GatewayCacheService gatewayCacheService;
 
     @Transactional
-    public void overrideTMCaseIdWithRMOriginalCaseId(String caseID, NCOutcome ncOutcome) {
+    public String overrideTMCaseIdWithRMOriginalCaseId(String caseID) {
         GatewayCache gatewayCache = gatewayCacheService.getById(caseID);
-        ncOutcome.setCaseId(UUID.fromString(gatewayCache.getOriginalCaseId()));
+        return gatewayCache.getOriginalCaseId();
     }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hardrefusal/HardRefusalReceivedProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hardrefusal/HardRefusalReceivedProcessorTest.java
@@ -22,6 +22,7 @@ import uk.gov.ons.census.fwmt.outcomeservice.service.impl.GatewayCacheService;
 import uk.gov.ons.census.fwmt.outcomeservice.template.TemplateCreator;
 
 import java.text.DateFormat;
+import java.time.Instant;
 import java.util.Date;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -80,6 +81,15 @@ public class HardRefusalReceivedProcessorTest {
     Assertions.assertEquals(outcome.getCaseId().toString(), caseId);
     Assertions.assertEquals("Test123, Dangerous address", careCodes);
     Assertions.assertEquals(outcome.getAccessInfo(), accessInfo);
+  }
+
+  @Test
+  @DisplayName("Should throw an error if the cache does not exist")
+  public void shouldThrowErrorIfCacheDoesNotExistForHardRefusal() throws GatewayException {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomne();
+    Assertions.assertThrows(GatewayException.class, () -> {
+      hardRefusalReceivedProcessor.process(outcome, outcome.getCaseId(), "HH");
+    });
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.fwmt.outcomeservice.helpers;
 
+import uk.gov.ons.census.fwmt.common.data.nc.NCOutcome;
 import uk.gov.ons.census.fwmt.common.data.shared.Refusal;
 import uk.gov.ons.census.fwmt.outcomeservice.dto.CareCodeDto;
 import uk.gov.ons.census.fwmt.outcomeservice.dto.OutcomeSuperSetDto;

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/service/impl/NCTMCaseIdOverrideTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/service/impl/NCTMCaseIdOverrideTest.java
@@ -1,16 +1,13 @@
 package uk.gov.ons.census.fwmt.outcomeservice.service.impl;
 
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.ons.census.fwmt.common.data.nc.NCOutcome;
 import uk.gov.ons.census.fwmt.outcomeservice.data.GatewayCache;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -27,11 +24,10 @@ public class NCTMCaseIdOverrideTest {
     public void shouldOverrideTMCaseIdWithRMOriginalCaseId() {
         GatewayCache gatewayCache = new GatewayCache();
         gatewayCache.setOriginalCaseId("a48bf28e-e7f4-4467-a9fb-e000b6a55676");
-        NCOutcome ncOutcome = new NCOutcome();
 
         when(gatewayCacheService.getById(anyString())).thenReturn(gatewayCache);
-        nctmCaseIdOverride.overrideTMCaseIdWithRMOriginalCaseId("b48bf28e-e7f4-4467-a9fb-e000b6a33543", ncOutcome);
-        assertThat("a48bf28e-e7f4-4467-a9fb-e000b6a55676", is(equalTo(ncOutcome.getCaseId().toString())));
+        String caseId = nctmCaseIdOverride.overrideTMCaseIdWithRMOriginalCaseId("b48bf28e-e7f4-4467-a9fb-e000b6a33543");
+        Assertions.assertEquals("a48bf28e-e7f4-4467-a9fb-e000b6a55676", caseId);
         verify(gatewayCacheService, times(1)).getById(anyString());
     }
 }


### PR DESCRIPTION
…ent, have updated the logging, have improved the performance of the NCTMCaseOverride and have added and updated unit tests

# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
https://collaborate2.ons.gov.uk/jira/browse/FWMT-3116

# Proposed Changes
Have updated the hard refusal processor to error is it receives a hard refusal that has no previous record in cache. Have also tidied up the NCTMCaseOverride class and have added additional logging. The unit tests have been created and updated.
# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Run a hard refusal for a case that has no recorded cache

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1680" alt="Screenshot 2021-01-15 at 12 20 46" src="https://user-images.githubusercontent.com/47788084/104728701-363d5280-572f-11eb-8945-52f14d666f2c.png">
<img width="1680" alt="Screenshot 2021-01-15 at 12 05 17" src="https://user-images.githubusercontent.com/47788084/104728709-3a697000-572f-11eb-89e2-914d97d87c3f.png">

