### PR TITLE
exlude ceExpectedCapcity when case is not CE

### DIFF
--- a/src/main/resources/templates/payload/NEW_ADDRESS_REPORTED-event.ftl
+++ b/src/main/resources/templates/payload/NEW_ADDRESS_REPORTED-event.ftl
@@ -46,7 +46,7 @@
     "addressType" : "${surveyType}",
     "region" :"${region}"
 }
-    <#if usualResidents??>
+    <#if surveyType == "CE">
     ,"ceExpectedCapacity" : "${usualResidents?c}"
     </#if>
 }


### PR DESCRIPTION
# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
- https://collaborate2.ons.gov.uk/jira/browse/PPP-8647

# Proposed Changes
- Adjusted the tempale for new address to only include ceExpectedCapacity when the survey type is CE

# Checklist
- [ ] Unit Test written 
- [ ] Acceptance Tests updated
- [x] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
- After testing RM will see they dont reieve ceExpectedCapacity unless the survey type is CE

# Screenshots

- Screen shot of Passed Unit/Acceptance Test


