### PR TITLE
Have swapped siteCaseId for caseId in the CancelFeedbackLongPauseProc…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/converter/impl/CancelHHFeedbackLongPauseProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/converter/impl/CancelHHFeedbackLongPauseProcessor.java
@@ -30,15 +30,14 @@ public class CancelHHFeedbackLongPauseProcessor implements OutcomeServiceProcess
         gatewayEventManager.triggerEvent(String.valueOf(caseId), PROCESSING_OUTCOME,
             SURVEY_TYPE, type,
             PROCESSOR, "FEEDBACK_LONG_PAUSE",
-            ORIGINAL_CASE_ID, String.valueOf(outcome.getCaseId()),
-            SITE_CASE_ID, (outcome.getSiteCaseId() != null ? String.valueOf(outcome.getSiteCaseId()) : "N/A"));
+            ORIGINAL_CASE_ID, String.valueOf(outcome.getCaseId()));
 
         FwmtCancelActionInstruction fieldworkCancel = FwmtCancelActionInstruction.builder()
                 .actionInstruction(ActionInstructionType.CANCEL)
                 .surveyName("CENSUS")
                 .addressType("HH")
                 .addressLevel("U")
-                .caseId(String.valueOf(outcome.getSiteCaseId()))
+                .caseId(String.valueOf(outcome.getCaseId()))
                 .build();
 
         rmFieldRepublishProducer.republish(fieldworkCancel);

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
@@ -50,4 +50,25 @@ public class HardRefusalHelper {
     outcomeSuperSetDto.setTransactionId(UUID.randomUUID());
     return outcomeSuperSetDto;
   }
+
+  public OutcomeSuperSetDto createHardRefusalOutcomeWithSite() {
+    OutcomeSuperSetDto outcomeSuperSetDto = new OutcomeSuperSetDto();
+    outcomeSuperSetDto.setCaseId(UUID.fromString("e04cbf10-597b-11eb-ae93-0242ac130002"));
+    outcomeSuperSetDto.setOutcomeCode("Test");
+    List<CareCodeDto> careCodeDto = new ArrayList<>();
+    careCodeDto.add(CareCodeDto.builder().careCode("Test123").build());
+    outcomeSuperSetDto.setCareCodes(careCodeDto);
+    outcomeSuperSetDto.setAccessInfo("12345");
+    Refusal refusal = new Refusal();
+    refusal.setTitle("Mr");
+    refusal.setFirstname("John");
+    refusal.setSurname("Smith");
+    refusal.setDangerous(true);
+    refusal.setHouseholder(true);
+    outcomeSuperSetDto.setRefusal(refusal);
+    outcomeSuperSetDto.setOfficerId("Test");
+    outcomeSuperSetDto.setTransactionId(UUID.randomUUID());
+    outcomeSuperSetDto.setSiteCaseId(UUID.fromString("bd6345af-d706-43d3-a13b-8c549e081a76"));
+    return outcomeSuperSetDto;
+  }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hhfeedbacklongpause/CancelHHFeedbackLongPauseProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hhfeedbacklongpause/CancelHHFeedbackLongPauseProcessorTest.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.census.fwmt.outcomeservice.hhfeedbacklongpause;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,20 +11,17 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
 import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
 import uk.gov.ons.census.fwmt.outcomeservice.config.OutcomeSetup;
 import uk.gov.ons.census.fwmt.outcomeservice.converter.RefusalEncryptionLookup;
 import uk.gov.ons.census.fwmt.outcomeservice.converter.impl.CancelHHFeedbackLongPauseProcessor;
-import uk.gov.ons.census.fwmt.outcomeservice.converter.impl.HardRefusalReceivedProcessor;
 import uk.gov.ons.census.fwmt.outcomeservice.data.GatewayCache;
 import uk.gov.ons.census.fwmt.outcomeservice.dto.OutcomeSuperSetDto;
 import uk.gov.ons.census.fwmt.outcomeservice.helpers.HardRefusalHelper;
 import uk.gov.ons.census.fwmt.outcomeservice.message.GatewayOutcomeProducer;
 import uk.gov.ons.census.fwmt.outcomeservice.message.RmFieldRepublishProducer;
-import uk.gov.ons.census.fwmt.outcomeservice.service.impl.GatewayCacheService;
 import uk.gov.ons.census.fwmt.outcomeservice.template.TemplateCreator;
 
 import java.text.DateFormat;
@@ -30,7 +29,6 @@ import java.util.Date;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CancelHHFeedbackLongPauseProcessorTest {
@@ -62,9 +60,6 @@ public class CancelHHFeedbackLongPauseProcessorTest {
   @Mock
   private OutcomeSetup outcomeSetup;
 
-  @Mock
-  private GatewayOutcomeProducer gatewayOutcomeProducer;
-
   @Captor
   private ArgumentCaptor<FwmtCancelActionInstruction> longPause;
 
@@ -73,5 +68,15 @@ public class CancelHHFeedbackLongPauseProcessorTest {
   public void shouldSendFwmtCancelActionInstructionToRm() throws GatewayException {
     final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomne();
     Assertions.assertEquals(outcome.getCaseId(), cancelHHFeedbackLongPauseProcessor.process(outcome, outcome.getCaseId(), "HH"));
+  }
+
+  @Test
+  @DisplayName("Should send FwmtCancelActionInstruction to TM with caseId not siteCaseId")
+  public void shouldSendCaseIdToRm() throws GatewayException, JSONException {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomeWithSite();
+    cancelHHFeedbackLongPauseProcessor.process(outcome, outcome.getCaseId(), "HH");
+    verify(rmFieldRepublishProducer).republish(longPause.capture());
+    FwmtCancelActionInstruction sentPause = longPause.getValue();
+    Assertions.assertEquals(outcome.getCaseId().toString(), sentPause.getCaseId());
   }
 }


### PR DESCRIPTION
…essor as this is HH only and elad to errors in JS

# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
https://collaborate2.ons.gov.uk/jira/browse/PPP-8782 and https://collaborate2.ons.gov.uk/jira/browse/FWMT-3331

# Proposed Changes
Have updated the CancelFeedbackLongPause to send the caseId as a cancel to JS and not siteCaseId (this is for CEs). This processor is only used by HH and was leading to issues in JS. Have also removed the site case ID log line and have added a unit test.

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Run a HH feedback long pause.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1680" alt="Screenshot 2021-02-18 at 12 21 44" src="https://user-images.githubusercontent.com/47788084/108356357-f234e600-71e3-11eb-9c54-f95ea2cd391a.png">
