### PR TITLE
Have updated the GatewayOutcomeProducer to accept fields with carriag…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/message/GatewayOutcomeProducer.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/message/GatewayOutcomeProducer.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.fwmt.outcomeservice.message;
 
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Message;
@@ -36,6 +37,9 @@ public class GatewayOutcomeProducer {
     long epochMilli = Instant.now().toEpochMilli();
     messageProperties.setTimestamp(new Date(epochMilli));
     MessageConverter messageConverter = new Jackson2JsonMessageConverter();
+
+    objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(),
+        true);
 
     try {
       Message message = messageConverter.toMessage(objectMapper.readTree(outcomeEvent), messageProperties);

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/message/GatewayOutcomeProducerTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/message/GatewayOutcomeProducerTest.java
@@ -1,0 +1,101 @@
+package uk.gov.ons.census.fwmt.outcomeservice.hardrefusal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.fwmt.common.error.GatewayException;
+import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
+import uk.gov.ons.census.fwmt.outcomeservice.config.OutcomeSetup;
+import uk.gov.ons.census.fwmt.outcomeservice.converter.RefusalEncryptionLookup;
+import uk.gov.ons.census.fwmt.outcomeservice.converter.impl.HardRefusalReceivedProcessor;
+import uk.gov.ons.census.fwmt.outcomeservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.outcomeservice.dto.OutcomeSuperSetDto;
+import uk.gov.ons.census.fwmt.outcomeservice.helpers.HardRefusalHelper;
+import uk.gov.ons.census.fwmt.outcomeservice.message.GatewayOutcomeProducer;
+import uk.gov.ons.census.fwmt.outcomeservice.service.impl.GatewayCacheService;
+import uk.gov.ons.census.fwmt.outcomeservice.template.TemplateCreator;
+
+import java.text.DateFormat;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class HardRefusalReceivedProcessorTest {
+
+  @InjectMocks
+  private HardRefusalReceivedProcessor hardRefusalReceivedProcessor;
+
+  @Mock
+  private GatewayCacheService cacheService;
+
+  @Mock
+  private GatewayCache gatewayCache;
+
+  @Mock
+  private GatewayEventManager eventManager;
+
+  @Mock
+  private TemplateCreator temmplateCreator;
+
+  @Mock
+  private RefusalEncryptionLookup refusalEncryptionLookup;
+
+  @Mock
+  private DateFormat dateFormat;
+
+  @Mock
+  private Date date;
+
+  @Mock
+  private OutcomeSetup outcomeSetup;
+
+  @Mock
+  private GatewayOutcomeProducer gatewayOutcomeProducer;
+
+  @Captor
+  private ArgumentCaptor<GatewayCache> spiedCache;
+
+  @Test
+  @DisplayName("Should update the cache")
+  public void shouldUpdateHareRefusalCache() throws GatewayException {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomne();
+    GatewayCache mockEntry = new GatewayCache();
+    mockEntry.setCaseId(outcome.getCaseId().toString());
+    when(cacheService.getById(outcome.getCaseId().toString())).thenReturn(mockEntry);
+    when(dateFormat.format(any())).thenReturn("2020-04-17T11:53:11.000+0000");
+    hardRefusalReceivedProcessor.process(outcome, outcome.getCaseId(), "HH");
+    verify(cacheService).save(spiedCache.capture());
+    String caseId = spiedCache.getValue().caseId;
+    String careCodes = spiedCache.getValue().careCodes;
+    String accessInfo = spiedCache.getValue().accessInfo;
+    Assertions.assertEquals(outcome.getCaseId().toString(), caseId);
+    Assertions.assertEquals("Test123, Dangerous address", careCodes);
+    Assertions.assertEquals(outcome.getAccessInfo(), accessInfo);
+  }
+
+  @Test
+  @DisplayName("Should throw an error if the cache does not exist")
+  public void shouldThrowErrorIfCacheDoesNotExistForHardRefusal() throws GatewayException {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomne();
+    Assertions.assertThrows(GatewayException.class, () -> {
+      hardRefusalReceivedProcessor.process(outcome, outcome.getCaseId(), "HH");
+    });
+  }
+
+  @Test
+  @DisplayName("IsDangerous field should return false is null")
+  public void shouldReturnIsDangerousAsFalseIfNull() {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomneWithNullDangerous();
+    Assertions.assertEquals(false, outcome.getRefusal().isDangerous());
+  }
+}


### PR DESCRIPTION
…e returns in

# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
https://collaborate2.ons.gov.uk/jira/browse/FWMT-3402

# Proposed Changes
GatewayOutcomeProducer has been updated to accept any JSON from TM where the field officer has accidentally added a carriage return the to fields due to copy and pasting.

# Checklist
- [ ] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Send a CE estab new standalone address from the device with one of the fields containing an extra line.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test


