### PR TITLE
Have added a check to prevent the hard refusal processor failing due …

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/converter/impl/HardRefusalReceivedProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/converter/impl/HardRefusalReceivedProcessor.java
@@ -158,7 +158,7 @@ public class HardRefusalReceivedProcessor implements OutcomeServiceProcessor {
     int typeCache = type.equals("CE") ? 1 : 10;
     String dangerousCareCode;
     String updateCareCodes;
-    if (type.equals("HH")) {
+    if (type.equals("HH") && !outcome.getOutcomeCode().equals("01-03-07")) {
       dangerousCareCode = outcome.getRefusal().isDangerous()  ? "Dangerous address" : "No safety issues";
       updateCareCodes = outcome.getCareCodes() != null ? OutcomeSuperSetDto.careCodesToText(outcome.getCareCodes()) + ", " + dangerousCareCode :
           dangerousCareCode;

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hardrefusal/HardRefusalReceivedProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hardrefusal/HardRefusalReceivedProcessorTest.java
@@ -98,4 +98,18 @@ public class HardRefusalReceivedProcessorTest {
     final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomneWithNullDangerous();
     Assertions.assertEquals(false, outcome.getRefusal().isDangerous());
   }
+
+  @Test
+  @DisplayName("Should not throw an error when receiving outcomecode 01-03-07")
+  public void shouldNotThrowAnErrorWhenReceivingOutcomeCode010307() throws GatewayException {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalWithOutcomeCode010307();
+    GatewayCache mockEntry = new GatewayCache();
+    mockEntry.setCaseId(outcome.getCaseId().toString());
+    when(cacheService.getById(outcome.getCaseId().toString())).thenReturn(mockEntry);
+    when(dateFormat.format(any())).thenReturn("2020-04-17T11:53:11.000+0000");
+    hardRefusalReceivedProcessor.process(outcome, outcome.getCaseId(), "HH");
+    verify(cacheService).save(spiedCache.capture());
+    String caseId = spiedCache.getValue().caseId;
+    Assertions.assertEquals(outcome.getCaseId().toString(), caseId);
+  }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
@@ -71,4 +71,17 @@ public class HardRefusalHelper {
     outcomeSuperSetDto.setSiteCaseId(UUID.fromString("bd6345af-d706-43d3-a13b-8c549e081a76"));
     return outcomeSuperSetDto;
   }
+
+  public OutcomeSuperSetDto createHardRefusalWithOutcomeCode010307() {
+    OutcomeSuperSetDto outcomeSuperSetDto = new OutcomeSuperSetDto();
+    outcomeSuperSetDto.setCaseId(UUID.randomUUID());
+    outcomeSuperSetDto.setOutcomeCode("01-03-07");
+    List<CareCodeDto> careCodeDto = new ArrayList<>();
+    careCodeDto.add(CareCodeDto.builder().careCode("Test123").build());
+    outcomeSuperSetDto.setCareCodes(careCodeDto);
+    outcomeSuperSetDto.setAccessInfo("12345");
+    outcomeSuperSetDto.setOfficerId("Test");
+    outcomeSuperSetDto.setTransactionId(UUID.randomUUID());
+    return outcomeSuperSetDto;
+  }
 }


### PR DESCRIPTION
…to receiving the outcome code 01-03-07

# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
https://collaborate2.ons.gov.uk/jira/browse/FWMT-3418

# Proposed Changes
Have updated the hard refusal processor to not process any HH that is received with an outcome code of 01-03-07

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Run an address not valid for a HH along with a hard refusal.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test
<img width="1680" alt="Screenshot 2021-03-23 at 15 45 17" src="https://user-images.githubusercontent.com/47788084/112175779-6c93c400-8bef-11eb-8061-5fca0aecff7a.png">


