### PR TITLE
Have added a null check on refusal object to prevent issues when an o…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/converter/impl/HardRefusalReceivedProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/outcomeservice/converter/impl/HardRefusalReceivedProcessor.java
@@ -158,7 +158,7 @@ public class HardRefusalReceivedProcessor implements OutcomeServiceProcessor {
     int typeCache = type.equals("CE") ? 1 : 10;
     String dangerousCareCode;
     String updateCareCodes;
-    if (type.equals("HH") && !outcome.getOutcomeCode().equals("01-03-07")) {
+    if (outcome.getRefusal() != null && type.equals("HH") && !outcome.getOutcomeCode().equals("01-03-07")) {
       dangerousCareCode = outcome.getRefusal().isDangerous()  ? "Dangerous address" : "No safety issues";
       updateCareCodes = outcome.getCareCodes() != null ? OutcomeSuperSetDto.careCodesToText(outcome.getCareCodes()) + ", " + dangerousCareCode :
           dangerousCareCode;

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hardrefusal/HardRefusalReceivedProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/hardrefusal/HardRefusalReceivedProcessorTest.java
@@ -93,7 +93,7 @@ public class HardRefusalReceivedProcessorTest {
   }
 
   @Test
-  @DisplayName("IsDangerous field should return false is null")
+  @DisplayName("IsDangerous field should return false if null")
   public void shouldReturnIsDangerousAsFalseIfNull() {
     final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalOutcomneWithNullDangerous();
     Assertions.assertEquals(false, outcome.getRefusal().isDangerous());
@@ -103,6 +103,20 @@ public class HardRefusalReceivedProcessorTest {
   @DisplayName("Should not throw an error when receiving outcomecode 01-03-07")
   public void shouldNotThrowAnErrorWhenReceivingOutcomeCode010307() throws GatewayException {
     final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalWithOutcomeCode010307();
+    GatewayCache mockEntry = new GatewayCache();
+    mockEntry.setCaseId(outcome.getCaseId().toString());
+    when(cacheService.getById(outcome.getCaseId().toString())).thenReturn(mockEntry);
+    when(dateFormat.format(any())).thenReturn("2020-04-17T11:53:11.000+0000");
+    hardRefusalReceivedProcessor.process(outcome, outcome.getCaseId(), "HH");
+    verify(cacheService).save(spiedCache.capture());
+    String caseId = spiedCache.getValue().caseId;
+    Assertions.assertEquals(outcome.getCaseId().toString(), caseId);
+  }
+
+  @Test
+  @DisplayName("Should not throw an error when receiving a refusal without a refusal object")
+  public void shouldNotThrowAnErrorWhenReceivingARefusalWithoutARefusalObject() throws GatewayException {
+    final OutcomeSuperSetDto outcome = new HardRefusalHelper().createHardRefusalWithoutRefusalObject();
     GatewayCache mockEntry = new GatewayCache();
     mockEntry.setCaseId(outcome.getCaseId().toString());
     when(cacheService.getById(outcome.getCaseId().toString())).thenReturn(mockEntry);

--- a/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/outcomeservice/helpers/HardRefusalHelper.java
@@ -84,4 +84,17 @@ public class HardRefusalHelper {
     outcomeSuperSetDto.setTransactionId(UUID.randomUUID());
     return outcomeSuperSetDto;
   }
+
+  public OutcomeSuperSetDto createHardRefusalWithoutRefusalObject() {
+    OutcomeSuperSetDto outcomeSuperSetDto = new OutcomeSuperSetDto();
+    outcomeSuperSetDto.setCaseId(UUID.randomUUID());
+    outcomeSuperSetDto.setOutcomeCode("03-02-01");
+    List<CareCodeDto> careCodeDto = new ArrayList<>();
+    careCodeDto.add(CareCodeDto.builder().careCode("Test123").build());
+    outcomeSuperSetDto.setCareCodes(careCodeDto);
+    outcomeSuperSetDto.setAccessInfo("12345");
+    outcomeSuperSetDto.setOfficerId("Test");
+    outcomeSuperSetDto.setTransactionId(UUID.randomUUID());
+    return outcomeSuperSetDto;
+  }
 }


### PR DESCRIPTION
…fficer can't capture the refusal info

# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira
https://collaborate2.ons.gov.uk/jira/browse/FWMT-3428

# Proposed Changes
Have updated the HardRefusalReceivedProcessor to check if the refusal object is null and to send this as blank to RM (following the same route as a CE refusal). Have also added unit tests.

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
- How to demonstrate functionality  
Fill in a HH hard refusal with the refusal section blank.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1680" alt="Screenshot 2021-03-31 at 11 27 45" src="https://user-images.githubusercontent.com/47788084/113130891-74b5ba00-9214-11eb-91bd-243233434ba7.png">

